### PR TITLE
Removed mandatory patients_info calls

### DIFF
--- a/configs/MEDS/default_event.yaml
+++ b/configs/MEDS/default_event.yaml
@@ -1,6 +1,6 @@
 subject_id_col: subject_id
 
-subject:
+patients_info:
   subject_id_col: subject_id
   dob:
     code: 

--- a/configs/preMEDS/fetal_SP_synth.yaml
+++ b/configs/preMEDS/fetal_SP_synth.yaml
@@ -17,8 +17,9 @@ paths:
 
 write_file_type: csv
 subject_id_mapping:
-  filename: ${paths.tables_dir}/patient_info.csv
-  subject_id_col: CPR
+  file: ${paths.tables_dir}/patient_info.csv # Table to derive mapping from (can be None)
+  subject_id_col: CPR # Column to use as the subject_id mapping
+  mapping_id_col: # Column to use as the mapping (can be None, then auto-generated)
 
 tables:
   diagnosis:

--- a/configs/preMEDS/fetal_SP_synth.yaml
+++ b/configs/preMEDS/fetal_SP_synth.yaml
@@ -15,7 +15,10 @@ paths:
   tables_dir: ${oc.env:EHR2MEDS_DATA}/raw/fetal_data/SDS_AND_SP_from_population  
   output: ${oc.env:EHR2MEDS_DATA}/preMEDS/fetal_data/SP
 
-write_file_type: csv 
+write_file_type: csv
+subject_id_mapping:
+  filename: ${paths.concepts}/patient_info.csv
+  subject_id_col: CPR
 
 tables:
   diagnosis:
@@ -79,10 +82,10 @@ tables:
       - column: diagnosetype
         prefix: "RD_TYPE/"
 
-patients_info:
-  filename: ${paths.tables_dir}/patient_info.csv
-  rename_columns:
-    CPR: subject_id
-    Birthdate: birthdate
-    Deathdate: deathdate
-    Gender: gender
+  patients_info:
+    filename: ${paths.tables_dir}/patient_info.csv
+    rename_columns:
+      CPR: subject_id
+      Birthdate: birthdate
+      Deathdate: deathdate
+      Gender: gender

--- a/configs/preMEDS/fetal_SP_synth.yaml
+++ b/configs/preMEDS/fetal_SP_synth.yaml
@@ -17,7 +17,7 @@ paths:
 
 write_file_type: csv
 subject_id_mapping:
-  filename: ${paths.concepts}/patient_info.csv
+  filename: ${paths.tables_dir}/patient_info.csv
   subject_id_col: CPR
 
 tables:

--- a/configs/preMEDS/fetal_ngc.yaml
+++ b/configs/preMEDS/fetal_ngc.yaml
@@ -27,6 +27,11 @@ align_timestamps: # removes information that is not in the global format
   names: [timestamp]
   format: "%Y-%m-%d %H:%M:%S.%f"
 
+subject_id_mapping:
+  file: ${paths.tables_dir}/SP/tables/Mor - CPMI - Patientinfo.csv # Table to derive mapping from (can be None)
+  subject_id_col: MOR_CPR # Column to use as the subject_id mapping
+  mapping_id_col: # Column to use as the mapping (can be None, then auto-generated)
+
 tables:
   admissions:
     filename: ${paths.tables_dir}/SP/tables/Mor - CPMI - ADT hændelser.csv
@@ -322,12 +327,12 @@ tables:
     numeric_columns: [numeric_value]
 
 
-# TODO Add smoking status
-# Todo support multiple patient_infos
-patients_info:
-  filename: ${paths.tables_dir}/SP/tables/Mor - CPMI - Patientinfo.csv
-  rename_columns:
-    MOR_CPR: subject_id
-    Fødselsdato: birthdate
-    Dødsdato: deathdate
-    Køn: gender
+  # TODO Add smoking status
+  # Todo support multiple patient_infos
+  patients_info:
+    filename: ${paths.tables_dir}/SP/tables/Mor - CPMI - Patientinfo.csv
+    rename_columns:
+      MOR_CPR: subject_id
+      Fødselsdato: birthdate
+      Dødsdato: deathdate
+      Køn: gender

--- a/configs/preMEDS/lymphoma_ngc.yaml
+++ b/configs/preMEDS/lymphoma_ngc.yaml
@@ -23,6 +23,11 @@ align_timestamps: # removes information that is not in the global format
   names: [timestamp]
   format: "%Y-%m-%d %H:%M:%S"
 
+subject_id_mapping:
+  file: ${paths.tables_dir}/CPMI_PatientInfo.parquet # Table to derive mapping from (can be None)
+  subject_id_col: patientid # Column to use as the subject_id mapping
+  mapping_id_col: # Column to use as the mapping (can be None, then auto-generated)
+
 tables:
   SDS_dimpatologiskdiagnose:
       filename: ${paths.tables_dir}/SDS_dimpatologiskdiagnose.parquet
@@ -381,11 +386,11 @@ tables:
     code_prefix: "L/"
     numeric_columns: [numeric_value]
 
-patients_info:
-  filename: ${paths.tables_dir}/CPMI_PatientInfo.parquet
-  rename_columns:
-    patientid: subject_id
-    Fødselsdato: birthdate
-    Dødsdato: deathdate
-    Køn: gender
-  file_type: parquet
+  patients_info:
+    filename: ${paths.tables_dir}/CPMI_PatientInfo.parquet
+    rename_columns:
+      patientid: subject_id
+      Fødselsdato: birthdate
+      Dødsdato: deathdate
+      Køn: gender
+    file_type: parquet

--- a/ehr2meds/preMEDS/data_handler.py
+++ b/ehr2meds/preMEDS/data_handler.py
@@ -37,7 +37,7 @@ class DataHandler:
         # Initialize the appropriate data loader
         self.data_loader = DataLoader(chunksize, test)
 
-    def load_pandas(self, filename: str, cols: Optional[list[str]] = None, **kwargs) -> pd.DataFrame:
+    def load(self, filename: str, cols: Optional[list[str]] = None, **kwargs) -> pd.DataFrame:
         return self.data_loader.load_dataframe(filename=filename, cols=cols, **kwargs)
 
     def load_chunks(self, cfg: dict) -> Iterator[pd.DataFrame]:

--- a/ehr2meds/preMEDS/extractor.py
+++ b/ehr2meds/preMEDS/extractor.py
@@ -88,7 +88,7 @@ class PREMEDSExtractor:
         self,
         table_type: str,
         table_config: dict,
-        subject_id_mapping: Dict[str, int],
+        subject_id_mapping: Optional[Dict[str, int]] = None,
         time_stamp_dict: Optional[dict] = None,
     ) -> None:
         first_chunk = True
@@ -99,8 +99,8 @@ class PREMEDSExtractor:
             processed_chunk = self.processor.process(
                 chunk,
                 table_config,
-                subject_id_mapping,
                 self.data_handler,
+                subject_id_mapping,
                 time_stamp_dict,
             )
 

--- a/ehr2meds/preMEDS/extractor.py
+++ b/ehr2meds/preMEDS/extractor.py
@@ -1,6 +1,4 @@
 import logging
-import pickle
-import pandas as pd
 from ehr2meds.preMEDS.data_handler import DataHandler
 from ehr2meds.preMEDS.processors import Processor
 from tqdm import tqdm
@@ -54,7 +52,7 @@ class PREMEDSExtractor:
         map_col = self.cfg.subject_id_mapping.mapping_id_col
         df = (
             self.data_handler.load_pandas(
-                self.cfg.subject_id_mapping.filename,
+                self.cfg.subject_id_mapping.file,
                 cols=[id_col] + ([map_col] if map_col else []),
             )
             .dropna(subset=[id_col], how="any")

--- a/ehr2meds/preMEDS/extractor.py
+++ b/ehr2meds/preMEDS/extractor.py
@@ -1,6 +1,6 @@
 import logging
 import pickle
-from ehr2meds.preMEDS.constants import SUBJECT_ID
+import pandas as pd
 from ehr2meds.preMEDS.data_handler import DataHandler
 from ehr2meds.preMEDS.processors import Processor
 from tqdm import tqdm
@@ -51,25 +51,32 @@ class PREMEDSExtractor:
         # Load existing mapping if available
         logger.info("Loading dataframe for subject ID mapping")
         id_col = self.cfg.subject_id_mapping.subject_id_col
+        map_col = self.cfg.subject_id_mapping.mapping_id_col
         df = (
             self.data_handler.load_pandas(
                 self.cfg.subject_id_mapping.filename,
-                cols=[id_col],
+                cols=[id_col] + ([map_col] if map_col else []),
             )
-            .rename(columns={id_col: SUBJECT_ID})
-            .dropna(subset=[SUBJECT_ID], how="any")
-            .drop_duplicates(subset=[SUBJECT_ID])
+            .dropna(subset=[id_col], how="any")
+            .drop_duplicates(subset=[id_col])
         )
         logger.info(f"Number of patients in dataframe: {len(df)}")
-        if df[SUBJECT_ID].dtype != object:
-            df[SUBJECT_ID] = df[SUBJECT_ID].astype(str)
-        hash_to_int_map = dict(zip(df[SUBJECT_ID], range(len(df))))
+        if df[id_col].dtype != object:
+            df[id_col] = df[id_col].astype(str)
+
+        # Always sort by the ID column for consistent mapping
+        df = df.sort_values(by=id_col).reset_index(drop=True)
+
+        # If no mapping column is provided, create a int-based mapping
+        if not map_col:
+            df["mapping"] = df.index
+            map_col = "mapping"
+        subject_id_mapping = dict(zip(df[id_col], df[map_col]))
 
         # Save the mapping for reference.
-        with open(f"{self.cfg.paths.output}/hash_to_integer_map.pkl", "wb") as f:
-            pickle.dump(hash_to_int_map, f)
+        df.to_csv(f"{self.cfg.paths.output}/subject_id_mapping.csv", index=False)
 
-        return hash_to_int_map
+        return subject_id_mapping
 
     def format_tables(self, subject_id_mapping: Optional[Dict[str, int]] = None) -> None:
         """Process the tables using the data handler"""

--- a/ehr2meds/preMEDS/extractor.py
+++ b/ehr2meds/preMEDS/extractor.py
@@ -70,7 +70,7 @@ class PREMEDSExtractor:
 
         return hash_to_int_map
 
-    def format_tables(self, subject_id_mapping: Optional[Dict[str, int]]=None) -> None:
+    def format_tables(self, subject_id_mapping: Optional[Dict[str, int]] = None) -> None:
         """Process the tables using the data handler"""
         for table_type, table_config in self.cfg.get("tables", {}).items():
             logger.info(f"Processing table: {table_type}")

--- a/ehr2meds/preMEDS/extractor.py
+++ b/ehr2meds/preMEDS/extractor.py
@@ -51,7 +51,7 @@ class PREMEDSExtractor:
         id_col = self.cfg.subject_id_mapping.subject_id_col
         map_col = self.cfg.subject_id_mapping.mapping_id_col
         df = (
-            self.data_handler.load_pandas(
+            self.data_handler.load(
                 self.cfg.subject_id_mapping.file,
                 cols=[id_col] + ([map_col] if map_col else []),
             )

--- a/ehr2meds/preMEDS/extractor.py
+++ b/ehr2meds/preMEDS/extractor.py
@@ -2,15 +2,7 @@ import logging
 import pickle
 from ehr2meds.preMEDS.constants import SUBJECT_ID
 from ehr2meds.preMEDS.data_handler import DataHandler
-<<<<<<< HEAD
 from ehr2meds.preMEDS.processors import Processor
-from ehr2meds.preMEDS.utils import (
-    factorize_subject_id,
-    select_and_rename_columns,
-)
-=======
-from ehr2meds.preMEDS.utils import select_and_rename_columns
->>>>>>> dfd908f (Removed mandatory patients_info calls)
 from tqdm import tqdm
 from typing import Dict, Optional, Union
 

--- a/ehr2meds/preMEDS/extractor.py
+++ b/ehr2meds/preMEDS/extractor.py
@@ -50,13 +50,17 @@ class PREMEDSExtractor:
             return None
         # Load existing mapping if available
         logger.info("Loading dataframe for subject ID mapping")
-        df = self.data_handler.load_pandas(
-            self.cfg.subject_id_mapping,
-            cols=[SUBJECT_ID],
-        ).dropna(subset=[SUBJECT_ID], how="any").drop_duplicates(subset=[SUBJECT_ID])
+        id_col = self.cfg.subject_id_mapping.subject_id_col
+        df = (
+            self.data_handler.load_pandas(
+                self.cfg.subject_id_mapping.filename,
+                cols=[id_col],
+            ).rename(columns={id_col: SUBJECT_ID})
+            .dropna(subset=[SUBJECT_ID], how="any")
+            .drop_duplicates(subset=[SUBJECT_ID])
+        )
         logger.info(f"Number of patients in dataframe: {len(df)}")
 
-        self.data_handler.save(df, "subject")
         hash_to_int_map = dict(zip(df[SUBJECT_ID], range(len(df))))
 
         # Save the mapping for reference.

--- a/ehr2meds/preMEDS/extractor.py
+++ b/ehr2meds/preMEDS/extractor.py
@@ -61,7 +61,8 @@ class PREMEDSExtractor:
             .drop_duplicates(subset=[SUBJECT_ID])
         )
         logger.info(f"Number of patients in dataframe: {len(df)}")
-
+        if df[SUBJECT_ID].dtype != object:
+            df[SUBJECT_ID] = df[SUBJECT_ID].astype(str)
         hash_to_int_map = dict(zip(df[SUBJECT_ID], range(len(df))))
 
         # Save the mapping for reference.

--- a/ehr2meds/preMEDS/extractor.py
+++ b/ehr2meds/preMEDS/extractor.py
@@ -55,7 +55,8 @@ class PREMEDSExtractor:
             self.data_handler.load_pandas(
                 self.cfg.subject_id_mapping.filename,
                 cols=[id_col],
-            ).rename(columns={id_col: SUBJECT_ID})
+            )
+            .rename(columns={id_col: SUBJECT_ID})
             .dropna(subset=[SUBJECT_ID], how="any")
             .drop_duplicates(subset=[SUBJECT_ID])
         )

--- a/ehr2meds/preMEDS/extractor.py
+++ b/ehr2meds/preMEDS/extractor.py
@@ -2,13 +2,17 @@ import logging
 import pickle
 from ehr2meds.preMEDS.constants import SUBJECT_ID
 from ehr2meds.preMEDS.data_handler import DataHandler
+<<<<<<< HEAD
 from ehr2meds.preMEDS.processors import Processor
 from ehr2meds.preMEDS.utils import (
     factorize_subject_id,
     select_and_rename_columns,
 )
+=======
+from ehr2meds.preMEDS.utils import select_and_rename_columns
+>>>>>>> dfd908f (Removed mandatory patients_info calls)
 from tqdm import tqdm
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 logger = logging.getLogger(__name__)
 
@@ -46,38 +50,30 @@ class PREMEDSExtractor:
         self.processor = Processor()
 
     def __call__(self):
-        subject_id_mapping = self.format_patients_info()
+        subject_id_mapping = self.get_subject_id_mapping()
         self.format_tables(subject_id_mapping)
 
-    def format_patients_info(self) -> Dict[str, int]:
-        """
-        Load and process patient information, creating a mapping of patient IDs.
-
-        Returns:
-            Dict[str, int]: Mapping from original patient IDs to integer IDs
-        """
-        logger.info("Load patients info")
+    def get_subject_id_mapping(self) -> Union[None, Dict[str, int]]:
+        if not self.cfg.get("subject_id_mapping"):
+            return None
+        # Load existing mapping if available
+        logger.info("Loading dataframe for subject ID mapping")
         df = self.data_handler.load_pandas(
-            self.cfg.patients_info.filename,
-            cols=list(self.cfg.patients_info.get("rename_columns", {}).keys()),
-            **self.cfg.patients_info.get("file_info", {}),
-        )
-        # Use columns_map to subset and rename the columns.
-        df = select_and_rename_columns(df, self.cfg.patients_info.get("rename_columns", {}))
-        logger.info(f"Number of patients after selecting columns: {len(df)}")
+            self.cfg.subject_id_mapping,
+            cols=[SUBJECT_ID],
+        ).dropna(subset=[SUBJECT_ID], how="any").drop_duplicates(subset=[SUBJECT_ID])
+        logger.info(f"Number of patients in dataframe: {len(df)}")
 
-        df, hash_to_int_map = factorize_subject_id(df)
+        self.data_handler.save(df, "subject")
+        hash_to_int_map = dict(zip(df[SUBJECT_ID], range(len(df))))
+
         # Save the mapping for reference.
         with open(f"{self.cfg.paths.output}/hash_to_integer_map.pkl", "wb") as f:
             pickle.dump(hash_to_int_map, f)
 
-        df = df.dropna(subset=[SUBJECT_ID], how="any")
-        logger.info(f"Number of patients before saving: {len(df)}")
-        self.data_handler.save(df, "subject")
-
         return hash_to_int_map
 
-    def format_tables(self, subject_id_mapping: Dict[str, int]) -> None:
+    def format_tables(self, subject_id_mapping: Optional[Dict[str, int]]=None) -> None:
         """Process the tables using the data handler"""
         for table_type, table_config in self.cfg.get("tables", {}).items():
             logger.info(f"Processing table: {table_type}")

--- a/ehr2meds/preMEDS/processors.py
+++ b/ehr2meds/preMEDS/processors.py
@@ -24,8 +24,8 @@ class Processor:
     def process(
         df: pd.DataFrame,
         table_config: dict,
-        subject_id_mapping: Dict[str, int],
         data_handler: "DataHandler",
+        subject_id_mapping: Optional[Dict[str, int]]=None,
         time_stamp_dict: Optional[dict] = None,
     ) -> pd.DataFrame:
         """Process the table.

--- a/ehr2meds/preMEDS/processors.py
+++ b/ehr2meds/preMEDS/processors.py
@@ -74,7 +74,7 @@ class Processor:
         if not register_path.exists():
             filename = str(Path(__file__).parent.parent / "resources" / filename)
 
-        return data_handler.load_pandas(filename, cols=cols)
+        return data_handler.load(filename, cols=cols)
 
     @staticmethod
     def _apply_mappings(df: pd.DataFrame, table_config: dict, data_handler: "DataHandler") -> pd.DataFrame:

--- a/ehr2meds/preMEDS/processors.py
+++ b/ehr2meds/preMEDS/processors.py
@@ -57,7 +57,7 @@ class Processor:
         df = convert_numeric_columns(df, table_config)
         if time_stamp_dict:
             df = convert_timestamp_columns(df, **time_stamp_dict)
-        if subject_id_mapping:
+        if subject_id_mapping is not None:
             df = map_pids_to_ints(df, subject_id_mapping)
         df = clean_data(df)
         validate_subject_id(df)

--- a/ehr2meds/preMEDS/processors.py
+++ b/ehr2meds/preMEDS/processors.py
@@ -14,6 +14,7 @@ from ehr2meds.preMEDS.utils import (
     prefix_codes,
     select_and_rename_columns,
     unroll_columns,
+    validate_subject_id,
 )
 from pathlib import Path
 from typing import Dict, Optional
@@ -57,6 +58,7 @@ class Processor:
             df = convert_timestamp_columns(df, **time_stamp_dict)
         df = map_pids_to_ints(df, subject_id_mapping)
         df = clean_data(df)
+        validate_subject_id(df)
 
         return df
 

--- a/ehr2meds/preMEDS/processors.py
+++ b/ehr2meds/preMEDS/processors.py
@@ -26,7 +26,7 @@ class Processor:
         df: pd.DataFrame,
         table_config: dict,
         data_handler: "DataHandler",
-        subject_id_mapping: Optional[Dict[str, int]]=None,
+        subject_id_mapping: Optional[Dict[str, int]] = None,
         time_stamp_dict: Optional[dict] = None,
     ) -> pd.DataFrame:
         """Process the table.
@@ -41,6 +41,7 @@ class Processor:
         9. convert numeric columns
         10. apply pid integer mapping
         11. clean data
+        12. validate subject_id column
         """
         df = normalize_columns(df, table_config)
         df = apply_value_map(df, table_config)
@@ -56,7 +57,8 @@ class Processor:
         df = convert_numeric_columns(df, table_config)
         if time_stamp_dict:
             df = convert_timestamp_columns(df, **time_stamp_dict)
-        df = map_pids_to_ints(df, subject_id_mapping)
+        if subject_id_mapping:
+            df = map_pids_to_ints(df, subject_id_mapping)
         df = clean_data(df)
         validate_subject_id(df)
 

--- a/ehr2meds/preMEDS/utils.py
+++ b/ehr2meds/preMEDS/utils.py
@@ -46,42 +46,6 @@ def check_columns(df: pd.DataFrame, columns_map: dict):
         raise ValueError(error_msg)
 
 
-def factorize_subject_id(df: pd.DataFrame) -> Tuple[pd.DataFrame, Dict[str, int]]:
-    """Factorize the subject_id column into an integer mapping.
-
-    Args:
-        df: DataFrame containing SUBJECT_ID column
-
-    Returns:
-        Tuple[pd.DataFrame, Dict[str, int]]:
-            - DataFrame with integer subject IDs
-            - Mapping from original IDs to integer IDs
-
-    Example:
-        Input df[SUBJECT_ID]: ['A', 'B', 'C', 'D']
-        Output mapping: {'A': 1, 'B': 2, 'C': 3, 'D': 4}
-    """
-    # Convert to string to handle any array-like values
-    df[SUBJECT_ID] = df[SUBJECT_ID].astype(object).astype(str)
-
-    # Get unique values and create sequential mapping
-    unique_vals = df[SUBJECT_ID].unique()
-    hash_to_int_map = {
-        val: int(idx + 2) for idx, val in enumerate(sorted(unique_vals))
-    }  # +2 to prevent subject ids being read in as binary.
-
-    # Convert to object dtype before mapping to allow integer assignment
-    df[SUBJECT_ID] = df[SUBJECT_ID].astype(object)
-    # Map to integers
-    mapped = df[SUBJECT_ID].map(hash_to_int_map)
-    # Drop rows where mapping failed (NaN values) before converting to int
-    mask = mapped.notna()
-    df = df.loc[mask].copy()
-    # Create a new Series with int64 dtype explicitly
-    df[SUBJECT_ID] = pd.Series(mapped.loc[mask].values, dtype="int64", index=df.index)
-    return df, hash_to_int_map
-
-
 def apply_mapping(
     df,
     map_table,

--- a/ehr2meds/preMEDS/utils.py
+++ b/ehr2meds/preMEDS/utils.py
@@ -5,7 +5,7 @@ from ehr2meds.preMEDS.constants import (
     SUBJECT_ID,
     TIMESTAMP,
 )
-from typing import Dict, List, Tuple
+from typing import Dict, List
 
 
 def select_and_rename_columns(df: pd.DataFrame, columns_map: dict) -> pd.DataFrame:

--- a/ehr2meds/preMEDS/utils.py
+++ b/ehr2meds/preMEDS/utils.py
@@ -249,3 +249,14 @@ def prefix_codes(df: pd.DataFrame, code_prefix: str = None) -> pd.DataFrame:
     if code_prefix and CODE in df.columns:
         df[CODE] = code_prefix + df[CODE].astype(str)
     return df
+
+
+def validate_subject_id(df: pd.DataFrame) -> None:
+    """Checks that the subject_id column exists and is an integer"""
+    if SUBJECT_ID not in df.columns:
+        raise ValueError(f"Missing required column: {SUBJECT_ID}")
+    if not pd.api.types.is_integer_dtype(df[SUBJECT_ID]):
+        raise ValueError(
+            f"{SUBJECT_ID} column must be of integer type\n\
+                Hint: Use the subject_id_mapping configuration to map string IDs to integers."
+        )

--- a/ehr2meds/preMEDS/utils.py
+++ b/ehr2meds/preMEDS/utils.py
@@ -124,11 +124,13 @@ def convert_numeric_columns(df: pd.DataFrame, concept_config: dict) -> pd.DataFr
 def map_pids_to_ints(df: pd.DataFrame, subject_id_mapping: Dict[str, int]) -> pd.DataFrame:
     """Map string patient IDs to integers; keep only IDs that are in the mapping."""
     df[SUBJECT_ID] = df[SUBJECT_ID].astype(object).astype(str)
-    df = df[df[SUBJECT_ID].isin(subject_id_mapping)].copy()
-    mapped = df[SUBJECT_ID].map(subject_id_mapping)
-    mask = mapped.notna()
-    df = df.loc[mask].copy()
-    df[SUBJECT_ID] = pd.Series(mapped.loc[mask].astype(int).values, dtype="int64", index=df.index)
+
+    df[SUBJECT_ID] = df[SUBJECT_ID].map(subject_id_mapping)
+    if df[SUBJECT_ID].isna().any():
+        missing_ids = df[SUBJECT_ID][df[SUBJECT_ID].isna()].unique()
+        raise UserWarning(f"Found subject IDs in the data that are not in the mapping: {len(missing_ids)} unique missing IDs. Examples: {missing_ids[:10]}")
+    df = df.dropna(subset=[SUBJECT_ID], how="any")
+    df[SUBJECT_ID] = df[SUBJECT_ID].astype(int)
     return df
 
 

--- a/ehr2meds/preMEDS/utils.py
+++ b/ehr2meds/preMEDS/utils.py
@@ -128,7 +128,7 @@ def map_pids_to_ints(df: pd.DataFrame, subject_id_mapping: Dict[str, int]) -> pd
     df[SUBJECT_ID] = df[SUBJECT_ID].map(subject_id_mapping)
     if df[SUBJECT_ID].isna().any():
         missing_ids = df[SUBJECT_ID][df[SUBJECT_ID].isna()].unique()
-        raise UserWarning(f"Found subject IDs in the data that are not in the mapping: {len(missing_ids)} unique missing IDs. Examples: {missing_ids[:10]}")
+        print(f"Found {len(missing_ids)} subject IDs in the data that are not in the mapping. These IDs will be dropped")
     df = df.dropna(subset=[SUBJECT_ID], how="any")
     df[SUBJECT_ID] = df[SUBJECT_ID].astype(int)
     return df


### PR DESCRIPTION
EDIT: This PR is potentially not part of #37 -- Might've been previously fixed and this mapping is not related to the `subject_id_mapping`
1. Made `subject_id_mapping` optional per first part of #37 
>For instance, the code base currently enforces a mapping between pseudo_ids/CPR and patient_ids - but everything on SDS or similar is typically already hashed or something akin to this. 
2. Rephrased `patients_info` to `subject_id_mapping` keyword, making `patients_info` an optional (but standard) table that is handled similarly to the others, resolves #40 
>Currently a central patients info table containing the columns gender birthdate deathdate subject_id is a prerequesit when converting data from raw -> preMEDS. A functionallity that creates this central patients info table with the 4 variables, if they exist different tables, is needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed top-level config key: subject → patients_info
  * Added write_file_type: csv and a subject_id_mapping option to load IDs from external tables
  * Reformatted pre-MEDS table config for clearer subject ID mapping

* **Bug Fixes**
  * Added validation to ensure SUBJECT_ID exists and is integer
  * Improved subject ID mapping: reports missing/unknown IDs with a warning and drops unmatched rows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->